### PR TITLE
fix: correct calc anthropic streaming cost

### DIFF
--- a/litellm/cost_calculator.py
+++ b/litellm/cost_calculator.py
@@ -714,9 +714,10 @@ def completion_cost(  # noqa: PLR0915
                         and _usage["prompt_tokens_details"]
                     ):
                         prompt_tokens_details = _usage.get("prompt_tokens_details", {})
-                        cache_read_input_tokens = prompt_tokens_details.get(
-                            "cached_tokens", 0
-                        )
+                        cached_tokens = prompt_tokens_details.get("cached_tokens", 0)
+                        # only override cache_read_input_tokens if it is 0
+                        if cache_read_input_tokens == 0:
+                            cache_read_input_tokens = cached_tokens
 
                     total_time = getattr(completion_response, "_response_ms", 0)
 

--- a/litellm/cost_calculator.py
+++ b/litellm/cost_calculator.py
@@ -715,8 +715,7 @@ def completion_cost(  # noqa: PLR0915
                     ):
                         prompt_tokens_details = _usage.get("prompt_tokens_details", {})
                         cached_tokens = prompt_tokens_details.get("cached_tokens", 0)
-                        # only override cache_read_input_tokens if it is 0
-                        if cache_read_input_tokens == 0:
+                        if cached_tokens and cached_tokens > 0:
                             cache_read_input_tokens = cached_tokens
 
                     total_time = getattr(completion_response, "_response_ms", 0)

--- a/litellm/litellm_core_utils/llm_cost_calc/utils.py
+++ b/litellm/litellm_core_utils/llm_cost_calc/utils.py
@@ -209,7 +209,7 @@ def generic_cost_per_token(
             cast(
                 Optional[int], getattr(usage.prompt_tokens_details, "cached_tokens", 0)
             )
-            or 0
+            or usage._cache_read_input_tokens
         )
         text_tokens = (
             cast(

--- a/litellm/litellm_core_utils/llm_cost_calc/utils.py
+++ b/litellm/litellm_core_utils/llm_cost_calc/utils.py
@@ -107,7 +107,9 @@ def _generic_cost_per_character(
     return prompt_cost, completion_cost
 
 
-def _get_token_base_cost(model_info: ModelInfo, usage: Usage) -> Tuple[float, float, bool]:
+def _get_token_base_cost(
+    model_info: ModelInfo, usage: Usage
+) -> Tuple[float, float, bool]:
     """
     Return prompt cost for a given model and usage.
 
@@ -199,18 +201,24 @@ def generic_cost_per_token(
     prompt_cost = 0.0
     ### PROCESSING COST
     text_tokens = usage.prompt_tokens
-    cache_hit_tokens = 0
+    cache_hit_tokens = (
+        usage._cache_read_input_tokens
+        if usage and usage._cache_read_input_tokens
+        else 0
+    )
     audio_tokens = 0
     character_count = 0
     image_count = 0
     video_length_seconds = 0
     if usage.prompt_tokens_details:
-        cache_hit_tokens = (
+        cached_tokens = (
             cast(
                 Optional[int], getattr(usage.prompt_tokens_details, "cached_tokens", 0)
             )
-            or usage._cache_read_input_tokens
+            or 0
         )
+        if cached_tokens and cached_tokens > 0 and cached_tokens > cache_hit_tokens:
+            cache_hit_tokens = cached_tokens
         text_tokens = (
             cast(
                 Optional[int], getattr(usage.prompt_tokens_details, "text_tokens", None)
@@ -251,9 +259,13 @@ def generic_cost_per_token(
     prompt_cost = float(text_tokens) * prompt_base_cost
 
     ### CACHE READ COST
-    if above_threshold and model_info.get("cache_read_input_token_cost_above_200k_tokens"):
+    if above_threshold and model_info.get(
+        "cache_read_input_token_cost_above_200k_tokens"
+    ):
         prompt_cost += calculate_cost_component(
-            model_info, "cache_read_input_token_cost_above_200k_tokens", cache_hit_tokens
+            model_info,
+            "cache_read_input_token_cost_above_200k_tokens",
+            cache_hit_tokens,
         )
     else:
         prompt_cost += calculate_cost_component(


### PR DESCRIPTION
…input_tokens

## Title

<!-- e.g. "Implement user authentication feature" -->

## Relevant issues

- When in streaming mode using Anthropic provider, litellm misses cache read tokens when calculating cost -> leading to an increase in the final prompt cost.
- This PR fixes it.

<!-- e.g. "Fixes #000" -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🐛 Bug Fix
🧹 Refactoring
📖 Documentation
🚄 Infrastructure
✅ Test

## Changes


